### PR TITLE
Fix CI workflow: checkout before setup-go for proper caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: set up go 1.23
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: set up go
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
@@ -22,9 +25,6 @@ jobs:
         with:
           mongoDBVersion: "5.0"
 
-      - name: checkout
-        uses: actions/checkout@v4
-
       - name: build and test
         run: |
           export TZ="America/Chicago"
@@ -34,9 +34,9 @@ jobs:
           cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "_mock.go" > $GITHUB_WORKSPACE/profile.cov
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.6
 
       - name: submit coverage
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,55 +1,57 @@
-linters-settings:
-  govet:
-    enable:
-      - shadow
-  gocyclo:
-    min-complexity: 15
-  dupl:
-    threshold: 100
-  misspell:
-    locale: US
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-      - hugeParam
-
+version: "2"
+run:
+  concurrency: 4
 linters:
+  default: none
   enable:
-    - revive
-    - govet
-    - unconvert
-    - staticcheck
-    - unused
-    - gosec
-    - gocyclo
     - dupl
-    - misspell
-    - unparam
-    - typecheck
-    - ineffassign
-    - stylecheck
     - gochecknoinits
-    - copyloopvar
     - gocritic
+    - gocyclo
+    - govet
+    - ineffassign
+    - misspell
     - nakedret
-    - gosimple
     - prealloc
-  fast: false
-  disable-all: true
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    dupl:
+      threshold: 100
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - hugeParam
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+    misspell:
+      locale: US
 
-issues:
-  exclude-rules:
-    - text: "at least one file in a package should have a package comment"
-      linters:
-        - stylecheck
-    - text: "composites: go.mongodb.org/mongo-driver/bson/primitive.E struct literal uses unkeyed fields"
-      linters:
-        - govet
-    - text: "package-comments: should have a package comment"
-      linters:
-        - revive
-  exclude-use-default: false
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - staticcheck
+        text: "at least one file in a package should have a package comment"
+      - linters:
+          - govet
+        text: "composites: go.mongodb.org/mongo-driver/bson/primitive.E struct literal uses unkeyed fields"
+      - linters:
+          - revive
+        text: "package-comments: should have a package comment"
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Summary
- Move checkout step before setup-go to enable proper Go module caching
- setup-go needs go.mod/go.sum files to generate cache keys
- Update golangci-lint action to v7 and version to v2.6
- Migrate golangci-lint config from v1 to v2 format